### PR TITLE
Depend on Dart SDK v2.x.x

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,6 +2,9 @@ name: pausable_timer
 description: A timer that can be paused, resumed and reset.
 version: 0.1.0
 
+environment:
+  sdk: ">=2.7.0 <3.0.0"
+
 dependencies:
   clock: '^1.0.1'
 


### PR DESCRIPTION
If this is not specified, it means it depends on Dart 1. We used 2.7
as the minimum version because this is what Flutter uses, but it is not
really tested against any other version than 2.10 for now.