### PR TITLE
Migrate to null-safety

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
   test:
     strategy:
       matrix:
-        dart_version: ["2.7", "2.8", "2.9", "2.10"]
+        dart_version: ["2.12-beta"]
 
     runs-on: ubuntu-latest
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.2.0-nullsafety.0
+
+- Make package [null-safe](https://dart.dev/null-safety).
+
+  **NOTE:** This means the minimum supported Dart version has been bumped to 2.12.
+
 ## 0.1.0+2
 
 - Add example implementing a pausable countdown.

--- a/README.md
+++ b/README.md
@@ -74,15 +74,20 @@ void main() async {
 ## Example pausable countdown implementation
 
 ```dart
+/// Example on how to implement countdown making a PausableTimer periodic.
+
 import 'package:pausable_timer/pausable_timer.dart';
 
-/// Example on how to implement countdown making a PausableTimer periodic.
 void main() async {
-  PausableTimer timer;
+  // We need to make it nullable because we have a "circular dependency" between
+  // the callback and the variable. Since we are using the same variable we are
+  // initializing, the compiler can't guarantee the callback won't be called
+  // before the PausableTimer constructor finishes.
+  PausableTimer? timerInit;
   var countDown = 5;
 
   print('Create a periodic timer that fires every 1 second and starts it');
-  timer = PausableTimer(
+  timerInit = PausableTimer(
     Duration(seconds: 1),
     () {
       countDown--;
@@ -90,7 +95,9 @@ void main() async {
       // again, but it can be reused afterwards if needed. If we cancel the
       // timer, then it can be reused after the countdown is over.
       if (countDown > 0) {
-        timer
+        // we know the callback won't be called before the constructor ends, so
+        // it is safe to use !
+        timerInit!
           ..reset()
           ..start();
       }
@@ -98,6 +105,10 @@ void main() async {
       print('\t$countDown');
     },
   )..start();
+
+  // We create a new non-nullable binding for the timer to avoid writing timer!
+  // everywhere when we *know* it will be non-null.
+  PausableTimer timer = timerInit;
 
   print('And wait 2.1 seconds...');
   print('(0.1 extra to make sure there is no race between the timer and the '

--- a/example/countdown.dart
+++ b/example/countdown.dart
@@ -1,12 +1,17 @@
+/// Example on how to implement countdown making a PausableTimer periodic.
+
 import 'package:pausable_timer/pausable_timer.dart';
 
-/// Example on how to implement countdown making a PausableTimer periodic.
 void main() async {
-  PausableTimer timer;
+  // We need to make it nullable because we have a "circular dependency" between
+  // the callback and the variable. Since we are using the same variable we are
+  // initializing, the compiler can't guarantee the callback won't be called
+  // before the PausableTimer constructor finishes.
+  PausableTimer? timerInit;
   var countDown = 5;
 
   print('Create a periodic timer that fires every 1 second and starts it');
-  timer = PausableTimer(
+  timerInit = PausableTimer(
     Duration(seconds: 1),
     () {
       countDown--;
@@ -14,7 +19,9 @@ void main() async {
       // again, but it can be reused afterwards if needed. If we cancel the
       // timer, then it can be reused after the countdown is over.
       if (countDown > 0) {
-        timer
+        // we know the callback won't be called before the constructor ends, so
+        // it is safe to use !
+        timerInit!
           ..reset()
           ..start();
       }
@@ -22,6 +29,10 @@ void main() async {
       print('\t$countDown');
     },
   )..start();
+
+  // We create a new non-nullable binding for the timer to avoid writing timer!
+  // everywhere when we *know* it will be non-null.
+  final timer = timerInit;
 
   print('And wait 2.1 seconds...');
   print('(0.1 extra to make sure there is no race between the timer and the '

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,16 +3,16 @@ description: A timer implementation that can be paused, resumed and reset.
 homepage: https://github.com/llucax/pausable_timer
 repository: https://github.com/llucax/pausable_timer
 
-version: 0.1.0+2
+version: 0.2.0-nullsafety.0
 
 environment:
-  sdk: ">=2.7.0 <3.0.0"
+  sdk: ">=2.12.0-0 <3.0.0"
 
 dependencies:
-  clock: '^1.0.1'
+  clock: '^1.1.0-nullsafety.3'
 
 dev_dependencies:
   coverage: '^0.14.1'
-  test: '^1.15.2'
-  pedantic: '^1.9.0'
-  fake_async: '^1.0.1'
+  test: '^1.16.0-nullsafety.13'
+  pedantic: '^1.10.0-nullsafety.3'
+  fake_async: '^1.2.0-nullsafety.3'

--- a/test/pausable_timer_test.dart
+++ b/test/pausable_timer_test.dart
@@ -5,7 +5,7 @@ import 'package:pausable_timer/pausable_timer.dart';
 
 void main() {
   final oneSecond = Duration(seconds: 1);
-  int numCalls;
+  var numCalls = 0;
   void callback() => numCalls++;
 
   setUp(() => numCalls = 0);
@@ -34,11 +34,8 @@ void main() {
 
   test('constructor', () {
     final throwsAssertionError = throwsA(isA<AssertionError>());
-    expect(() => PausableTimer(null, callback), throwsAssertionError);
-    expect(() => PausableTimer(oneSecond, null), throwsAssertionError);
     expect(() => PausableTimer(Duration(seconds: -1), () {}),
         throwsAssertionError);
-    expect(() => PausableTimer(null, null), throwsAssertionError);
 
     for (final duration in [Duration.zero, oneSecond]) {
       final timer = PausableTimer(duration, callback);


### PR DESCRIPTION
For this we need to bump the minimum supported Dart version to 2.12 and upgrade the depepndencies to *nullsafety* pre-releases.

The `coverage` package doesn't really need to be null-safe because we only use it to run a tool from it (and when generating coverage reports only), which works fine with a null-safety ready dart compiler anyway.
