### PR TITLE
Fix check-dart action

### DIFF
--- a/.github/workflows/check-dart.yml
+++ b/.github/workflows/check-dart.yml
@@ -21,9 +21,14 @@ jobs:
 
     - name: Check latest version ${{ env.major }} docker image
       run: |
+        token=$(curl -s -H "Content-Type: application/json" \
+              "https://auth.docker.io/token?service=registry.docker.io&scope=repository:library/dart:pull" | \
+            jq -r .token)
         digest() {
-          curl -s -H "Content-Type: application/json" "https://hub.docker.com/v2/repositories/_/dart/tags/$1" |
-            jq .images[0].digest
+          curl -s -H "Content-Type: application/json" \
+                  -H "Authorization: Bearer $token" \
+                     "https://index.docker.io/v2/library/dart/manifests/$1" | \
+              jq -r '.fsLayers[0].blobSum'
         }
         digest_stable=$(digest stable)
         digest_current=$(digest $major.$latest_minor)

--- a/.github/workflows/check-dart.yml
+++ b/.github/workflows/check-dart.yml
@@ -25,7 +25,15 @@ jobs:
           curl -s -H "Content-Type: application/json" "https://hub.docker.com/v2/repositories/_/dart/tags/$1" |
             jq .images[0].digest
         }
-        if test "$(digest stable)" != "$(digest $major.$latest_minor)"
+        digest_stable=$(digest stable)
+        digest_current=$(digest $major.$latest_minor)
+        if test "$digest_stable" = null -o "$digest_current" = null
+        then
+          echo "Could not get the stable image digest ($digest_stable) or the currrent ($major.$latest_minor)" \
+            "image digest ($digest_current)." >&2
+            exit 1
+        fi
+        if test "$digest_stable" != "$digest_current"
         then
           echo "Version of $major.$latest_minor is not the latest stable" \
             "version for https://hub.docker.com/r/_/dart" >&2


### PR DESCRIPTION
The docker API seems to have changed and the dart version got outdated but this action was never failing. We update the action to use the latest docker API to get the image information.